### PR TITLE
インバイト通知のJSONの閉じ波括弧が欠ける場合に対応

### DIFF
--- a/VRChatActivityLogger/VRChatActivityLogger/VRChatActivityLogger.cs
+++ b/VRChatActivityLogger/VRChatActivityLogger/VRChatActivityLogger.cs
@@ -121,6 +121,12 @@ namespace VRChatActivityLogger
                     {
                         var m = RegexPatterns.ReceivedInviteDetail.Match(match.ToString());
                         var jsonRawDate = m.Groups[2].Value.Replace("{{", "{").Replace("}}", "}");
+                        var numCurlyBracketBegin = jsonRawDate.Count(c => c == '{');
+                        var numCurlyBracketEnd = jsonRawDate.Count(c => c == '}');
+                        if (numCurlyBracketBegin > numCurlyBracketEnd)
+                        {
+                            jsonRawDate += new string('}', numCurlyBracketBegin - numCurlyBracketEnd);
+                        }
                         dynamic content = JsonConvert.DeserializeObject(jsonRawDate);
                         var activityLog = new ActivityLog
                         {


### PR DESCRIPTION
VRChat側の問題だと思うのですが，インバイトのメッセージのJSONが閉じておらずがうまくパースできていない例を見つけたので修正を提案します．


現状でOKなLogの例（ユーザー名などは***にしています）
```
Received Message of type: notification content: {{"id":"***","type":"invite","senderUserId":"***","senderUsername":"***","receiverUserId":"***","message":"","details":{{"worldId":"***","worldName":"***"}},"created_at":"2020-07-28T14:11:32.475Z"}} received at 07/28/2020 14:11:32 UTC
```

修正が必要だったLogの例（ユーザー名などは***にしています）
```
Received Message of type: notification content: {{"id":"***","type":"invite","senderUserId":"***","senderUsername":"***","receiverUserId":"***","message":"This is a generated invite to ***","created_at":"2020-07-28T13:56:19.550Z","details":{{"worldId":"***","worldName":"***"}} received at 07/28/2020 13:56:19 UTC
```

このログはWebからInvite Meを行った際に生成されました．
現行版（v1.0.2）では以下のエラーログを出力して落ちます．

```
2020-07-30 12:59:59.3193 [INFO] VRChatActivityLoggerを実行します。
2020-07-30 12:59:59.3391 [DEBUG] ログを解析中 C:\Users\hakomoon\AppData\LocalLow\VRChat\VRChat\output_log_22-55-57.txt
2020-07-30 12:59:59.4230 [ERROR] Newtonsoft.Json.JsonSerializationException: Unexpected end when deserializing object. Path 'details', line 1, position 534.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateJObject(JsonReader reader)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value)
   at VRChatActivityLogger.VRChatActivityLogger.ParseVRChatLog(String filePath)
   at VRChatActivityLogger.VRChatActivityLogger.Run()
2020-07-30 12:59:59.4387 [INFO] VRChatActivityLoggerを終了します。
```