### PR TITLE
ユーザー名が空でパースに失敗する場合に対応

### DIFF
--- a/VRChatActivityLogger/VRChatActivityLogger/RegexPatterns.cs
+++ b/VRChatActivityLogger/VRChatActivityLogger/RegexPatterns.cs
@@ -79,7 +79,7 @@ namespace VRChatActivityLogger
             string receivedRequestInviteDetail = detailHeader + @"Received Message of type: notification content: ({{.+}}) received at";
             string sendInviteDetail = detailHeader + @".+to (.{40}) of.+worldId=(.+), worldName=(.+)}},";
             string sendRequestInviteDetail = detailHeader + @".+to (.{40}) of";
-            string metPlayerDetail = detailHeader + @"\[Player\] Initialized PlayerAPI ""(.+)"" is (remote|local)$";
+            string metPlayerDetail = detailHeader + @"\[Player\] Initialized PlayerAPI ""(.*)"" is (remote|local)$";
             string joinedRoom1Detail = detailHeader + @"\[RoomManager\] Joining (.+)$";
             string joinedRoom2Detail = detailHeader + @"\[RoomManager\] Joining or Creating Room: (.+)$";
             string sendFriendRequestDetail = detailHeader + @".+to (.{40}) of";


### PR DESCRIPTION
なぜかVRChatのログにlocalのユーザー名が適切に保存されていない場合があり，適切にパース出来ていなかった例がありました．
めったに踏まないケースなのだとは思いますが，一応修正提案をします．

- パースできるログ
`2021.01.12 02:36:09 Log        -  [Player] Initialized PlayerAPI "はこつき_hakomoon" is local`

- パースできていなかったログ
`2021.01.12 02:35:20 Log        -  [Player] Initialized PlayerAPI "" is local`
