### PR TITLE
VRChat 2021.1.2のアップデートでログが壊れた不具合の暫定対応

### DIFF
--- a/VRChatActivityLogger/VRChatActivityLogger/RegexPatterns.cs
+++ b/VRChatActivityLogger/VRChatActivityLogger/RegexPatterns.cs
@@ -51,9 +51,9 @@ namespace VRChatActivityLogger
             string receivedRequestInvite = header + @"Received Message of type: notification content:.+""type"":""requestInvite"".+$";
             string sendInvite = header + @"Send notification:.+type:invite.+$";
             string sendRequestInvite = header + @"Send notification:.+type:requestInvite.+$";
-            string joinedRoom1 = header + @"\[RoomManager\] Joining w.+$";
-            string joinedRoom2 = header + @"\[RoomManager\] Joining or Creating Room:.+$";
-            string metPlayer = header + @"\[Player\] Initialized PlayerAPI.+$";
+            string joinedRoom1 = header + @"\[(RoomManager|[Ǆǅ]*)\] Joining w.+$";
+            string joinedRoom2 = header + @"\[(RoomManager|[Ǆǅ]*)\] Joining or Creating Room:.+$";
+            string metPlayer = header + @"\[(Player|[Ǆǅ]*)\] Initialized PlayerAPI.+$";
             string sendFriendRequest = header + @"Send notification:.+type:friendRequest.+$";
             string receivedFriendRequest = header + @"Received Message of type: notification content:.+""type"":""friendRequest"".+$";
             string acceptFriendRequest = header + @"AcceptFriendRequest.+$";
@@ -79,9 +79,9 @@ namespace VRChatActivityLogger
             string receivedRequestInviteDetail = detailHeader + @"Received Message of type: notification content: ({{.+}}) received at";
             string sendInviteDetail = detailHeader + @".+to (.{40}) of.+worldId=(.+), worldName=(.+)}},";
             string sendRequestInviteDetail = detailHeader + @".+to (.{40}) of";
-            string metPlayerDetail = detailHeader + @"\[Player\] Initialized PlayerAPI ""(.*)"" is (remote|local)$";
-            string joinedRoom1Detail = detailHeader + @"\[RoomManager\] Joining (.+)$";
-            string joinedRoom2Detail = detailHeader + @"\[RoomManager\] Joining or Creating Room: (.+)$";
+            string metPlayerDetail = detailHeader + @"\[(Player|[Ǆǅ]*)\] Initialized PlayerAPI ""(.*)"" is (remote|local)$";
+            string joinedRoom1Detail = detailHeader + @"\[(RoomManager|[Ǆǅ]*)\] Joining (.+)$";
+            string joinedRoom2Detail = detailHeader + @"\[(RoomManager|[Ǆǅ]*)\] Joining or Creating Room: (.+)$";
             string sendFriendRequestDetail = detailHeader + @".+to (.{40}) of";
             string receivedFriendRequestDetail = detailHeader + @"Received Message of type: notification content: ({{.+}}) received at";
             string acceptFriendRequestDetail = detailHeader + @".+username:(.+), sender user id:(.{40}).+id: (.{40}),";

--- a/VRChatActivityLogger/VRChatActivityLogger/VRChatActivityLogger.cs
+++ b/VRChatActivityLogger/VRChatActivityLogger/VRChatActivityLogger.cs
@@ -211,7 +211,7 @@ namespace VRChatActivityLogger
                         {
                             ActivityType = ActivityType.JoinedRoom,
                             Timestamp = DateTime.Parse(m.Groups[1].Value),
-                            WorldID = m.Groups[2].Value,
+                            WorldID = m.Groups[3].Value,
                         });
                     }
                     else if (match.Groups[PatternType.JoinedRoom2].Value.Length != 0)
@@ -219,7 +219,7 @@ namespace VRChatActivityLogger
                         var m = RegexPatterns.JoinedRoom2Detail.Match(match.ToString());
                         if (activityLogs.Any() && activityLogs[activityLogs.Count - 1].ActivityType == ActivityType.JoinedRoom)
                         {
-                            activityLogs[activityLogs.Count - 1].WorldName = m.Groups[2].Value;
+                            activityLogs[activityLogs.Count - 1].WorldName = m.Groups[3].Value;
                         }
                         else
                         {
@@ -238,7 +238,7 @@ namespace VRChatActivityLogger
                         {
                             ActivityType = ActivityType.MetPlayer,
                             Timestamp = DateTime.Parse(m.Groups[1].Value),
-                            UserName = m.Groups[2].Value,
+                            UserName = m.Groups[3].Value,
                         });
                     }
                     else if (match.Groups[PatternType.SendFriendRequest].Value.Length != 0)


### PR DESCRIPTION
"とりあえず動かすための暫定対応" のプルリクエストになります。

・`[Player]` `[RoomManager]` が、 `U+01C4` と `U+01C5` で埋め尽くされていたので、正規表現の修正で対応しました
・上記二つが正しく取れているのは確認しました
・他のログについては、「フレンド承認」だけ取得できていることを確認しています（おそらく他は壊れていないため、取得できているかなと思いますが…）