### PR TITLE
ワールドのサムネイル画像を表示する機能を追加

### DIFF
--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/ActivityLogGridModel.cs
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/ActivityLogGridModel.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Media.Imaging;
 
 namespace VRChatActivityLogViewer
 {
     /// <summary>
     /// DataGridに表示するモデル
     /// </summary>
-    class ActivityLogGridModel
+    class ActivityLogGridModel : INotifyPropertyChanged
     {
         /// <summary>タイムスタンプ</summary>
         public DateTime TimeStamp { get; set; }
@@ -30,6 +33,32 @@ namespace VRChatActivityLogViewer
 
         /// <summary>ユーザID</summary>
         public string UserID { get; set; }
+
+        private BitmapImage _WorldImage;
+
+        /// <summary>ワールド画像</summary>
+        public BitmapImage WorldImage
+        {
+            get => _WorldImage;
+            set
+            {
+                if (value == _WorldImage) return;
+                _WorldImage = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// プロパティが変更されたときに発生するイベント
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// プロパティ変更を通知するメソッド
+        /// </summary>
+        /// <param name="propertyName"></param>
+        private void RaisePropertyChanged([CallerMemberName] string propertyName = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
         /// <summary>
         /// コンストラクタ

--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/MainWindow.xaml
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/MainWindow.xaml
@@ -97,7 +97,7 @@
         </Grid>
 
         <Border Grid.Row="2" BorderBrush="Silver" BorderThickness="1">
-            <DataGrid x:Name="ActivityLogGrid" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" RowHeight="30" CellStyle="{StaticResource Body_Content_DataGrid_Centering}" >
+            <DataGrid x:Name="ActivityLogGrid" AutoGenerateColumns="False" CanUserAddRows="False" IsReadOnly="True" MinRowHeight="30" CellStyle="{StaticResource Body_Content_DataGrid_Centering}" >
                 <DataGrid.ItemContainerStyle>
                     <Style TargetType="DataGridRow">
                         <Style.Triggers>
@@ -154,6 +154,16 @@
                                 <StackPanel Orientation="Horizontal">
                                     <Button Content="World ID" Width="64" Tag="{Binding}" Click="CopyWorldIDButton_Click" Visibility="{Binding IsCopyableWorldID, Converter={StaticResource BoolVisibilityConverter}}" Margin="5" />
                                     <Button Content="User ID" Width="64" Tag="{Binding}" Click="CopyUserIDButton_Click" Visibility="{Binding IsCopyableUserID, Converter={StaticResource BoolVisibilityConverter}}" Margin="5" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="Show Thumbnail">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal">
+                                    <Button Content="Show" Width="64" Tag="{Binding}" Click="ShowThumbnailButton_Click" Visibility="{Binding IsCopyableWorldID, Converter={StaticResource BoolVisibilityConverter}}" Margin="5" />
+                                    <Image Source="{Binding WorldImage}" Stretch="Uniform" Margin="5" ></Image>
                                 </StackPanel>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>

--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/WorldData.cs
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/WorldData.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.Serialization;
+
+namespace VRChatActivityLogViewer
+{
+    [System.Runtime.Serialization.DataContract]
+    class WorldData
+    {
+        /// <summary>ワールドに一意のID</summary>
+        [DataMember]
+        public string id;
+
+        /// <summary>ワールドの名前</summary>
+        [DataMember]
+        public string name;
+
+        /// <summary>ワールドの説明/summary>
+        [DataMember]
+        public string description;
+
+        /// <summary>ワールドの作者</summary>
+        [DataMember]
+        public string authorName;
+
+        /// <summary>ワールドの画像を示すURL</summary>
+        [DataMember]
+        public string imageUrl;
+
+        /// <summary>ワールドのサムネイル画像を示すURL</summary>
+        [DataMember]
+        public string thumbnailImageUrl;
+
+    }
+}


### PR DESCRIPTION
いつも便利に利用させていただいております。
名前があやふやなワールドを探すときに、サムネイル画像を表示できると便利かな？と思ったのでフォークして機能追加してみました。もしよければマージをご検討ください。

----
**サムネイル画像が表示されるまでのフロー**

1. DataGridの[Show]ボタンをクリック
2. イベントハンドラ内でワールド情報APIをコール
3. 戻ってきたJSONをパースしてサムネイル画像URLを取得
4. モデルのサムネイル画像を更新し、PropertyChangedを通知
5. DataGridにサムネイル画像が表示される