### PR TITLE
暫定修正: type:inviteResponseをinviteと解釈されてコケていたので修正

### DIFF
--- a/VRChatActivityLogger/VRChatActivityLogger/RegexPatterns.cs
+++ b/VRChatActivityLogger/VRChatActivityLogger/RegexPatterns.cs
@@ -49,7 +49,7 @@ namespace VRChatActivityLogger
 
             string receivedInvite = header + @"Received Message of type: notification content:.+""type"":""invite"".+$";
             string receivedRequestInvite = header + @"Received Message of type: notification content:.+""type"":""requestInvite"".+$";
-            string sendInvite = header + @"Send notification:.+type:invite.+$";
+            string sendInvite = header + @"Send notification:.+type:invite,.+$";
             string sendRequestInvite = header + @"Send notification:.+type:requestInvite.+$";
             string joinedRoom1 = header + @"\[RoomManager\] Joining w.+$";
             string joinedRoom2 = header + @"\[RoomManager\] Joining or Creating Room:.+$";


### PR DESCRIPTION
Invite/RequestInvite周りが変更されて、新たにnotification type: inviteResponseがログに出力されるようになっていました。
このログがinviteと間違って解釈されていたため、後の処理で必要な情報が取れずにログ取得に失敗していたので、暫定的に修正しました。

補足: 
・新しいログのタイプをすべて試したわけではありません（何があるかもすべて把握したわけではないです…）
・新しいログタイプの取得処理はありません