### PR TITLE
VRChat APIが403を返すようになったのでUserAgent文字列を追加

### DIFF
--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/VRChatApi/VRChatApiService.cs
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/VRChatApi/VRChatApiService.cs
@@ -27,12 +27,19 @@ namespace VRChatActivityLogViewer.VRChatApi
         /// </summary>
         private static JsonSerializerOptions jsonSerializerOptions;
 
+        /// <summary>
+        /// ユーザーエージェント文字列
+        /// </summary>
+        private static string userAgent = "Wget/1.20.3";
+
         static VRChatApiService()
         {
             jsonSerializerOptions = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
             };
+
+            client.DefaultRequestHeaders.Add("User-Agent", userAgent);
         }
 
         /// <summary>

--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/WebService.cs
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/WebService.cs
@@ -19,6 +19,16 @@ namespace VRChatActivityLogViewer
         private static HttpClient client = new HttpClient();
 
         /// <summary>
+        /// ユーザーエージェント文字列
+        /// </summary>
+        private static string userAgent = "Wget/1.20.3";
+
+        static WebService()
+        {
+            client.DefaultRequestHeaders.Add("User-Agent", userAgent);
+        }
+
+        /// <summary>
         /// URIを指定して画像をダウンロードする
         /// </summary>
         /// <param name="uri"></param>


### PR DESCRIPTION
VRChat APIがUser-Agentヘッダを設定していない状態だと403を返却してしまい、ワールド情報等の取得に失敗するようになっていました。そのため、`HttpClient.DefaultRequestHeaders.Add()` でUserAgent文字列を設定するよう修正しました。

※こちらがツールであることが分かりやすいように`Wget/1.20.3`を指定してみましたが、実際なんでもいいと思います。VRChat的にツールからの利用がNGの場合に蹴ってもらいやすいかなという配慮です。

よろしくお願いします！