### PR TITLE
詳細画面にワールド名をコピーするボタンを追加

### DIFF
--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/DetailWindow.xaml
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/DetailWindow.xaml
@@ -107,6 +107,7 @@
                 <StackPanel Orientation="Horizontal">
                     <Button x:Name="JoinButton" Content="Join" Margin="5" Width="100" Click="JoinButton_Click"/>
                     <Button x:Name="CopyWorldIdButton" Content="Copy World ID" Margin="5" Width="100" Click="CopyWorldIdButton_Click"/>
+                    <Button x:Name="CopyWorldNameButton" Content="Copy World Name" Margin="5" Width="150" Click="CopyWorldNameButton_Click"/>
                     <Button x:Name="CopyUserIdButton" Content="Copy User ID" Margin="5" Width="100" Click="CopyUserIdButton_Click"/>
                     <Button x:Name="CopyUrlButton" Content="Copy Url" Margin="5" Width="100" Click="CopyUrlButton_Click"/>
                 </StackPanel>

--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/DetailWindow.xaml.cs
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/DetailWindow.xaml.cs
@@ -295,6 +295,21 @@ namespace VRChatActivityLogViewer
         }
 
         /// <summary>
+        /// Copy World Nameボタンクリック時のイベント
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void CopyWorldNameButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (activityLog == null || activityLog.WorldName == null)
+            {
+                return;
+            }
+
+            Clipboard.SetText(activityLog.WorldName ?? "");
+        }
+
+        /// <summary>
         /// Copy User IDボタンクリック時のイベント
         /// </summary>
         /// <param name="sender"></param>


### PR DESCRIPTION
いつも便利に利用させていただいております。

[#VRChat_world紹介](https://twitter.com/search?q=%23VRChat_world%E7%B4%B9%E4%BB%8B)への投稿時など、ワールド名のコピーが手軽にできると嬉しい場面があります。そこで、詳細画面にワールド名をコピーするボタンを追加してみました。もしよければマージをご検討ください。

※DataGridで選択中の行の内容はショートカットキーでコピーできますが、タイムスタンプなど余計な情報も含まれてしまいます。