### PR TITLE
Copy系のボタンをクリックした際にコピーが失敗する場合への対処

### DIFF
--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/DetailWindow.xaml.cs
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/DetailWindow.xaml.cs
@@ -270,7 +270,7 @@ namespace VRChatActivityLogViewer
                 return;
             }
 
-            Clipboard.SetText(ActivityLog.WorldID ?? "");
+            Clipboard.SetDataObject(ActivityLog.WorldID ?? "");
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace VRChatActivityLogViewer
                 return;
             }
 
-            Clipboard.SetText(ActivityLog.WorldName ?? "");
+            Clipboard.SetDataObject(ActivityLog.WorldName ?? "");
         }
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace VRChatActivityLogViewer
                 return;
             }
 
-            Clipboard.SetText(ActivityLog.UserID ?? "");
+            Clipboard.SetDataObject(ActivityLog.UserID ?? "");
         }
 
         /// <summary>
@@ -315,7 +315,7 @@ namespace VRChatActivityLogViewer
                 return;
             }
 
-            Clipboard.SetText(ActivityLog.Url ?? "");
+            Clipboard.SetDataObject(ActivityLog.Url ?? "");
         }
 
         /// <summary>

--- a/VRChatActivityLogViewer/VRChatActivityLogViewer/MainWindow.xaml.cs
+++ b/VRChatActivityLogViewer/VRChatActivityLogViewer/MainWindow.xaml.cs
@@ -171,7 +171,7 @@ namespace VRChatActivityLogViewer
             {
                 if (button.Tag is ActivityLogGridModel tag)
                 {
-                    Clipboard.SetText(tag.WorldID ?? "");
+                    Clipboard.SetDataObject(tag.WorldID ?? "");
                 }
             }
         }
@@ -187,7 +187,7 @@ namespace VRChatActivityLogViewer
             {
                 if (button.Tag is ActivityLogGridModel tag)
                 {
-                    Clipboard.SetText(tag.UserID ?? "");
+                    Clipboard.SetDataObject(tag.UserID ?? "");
                 }
             }
         }


### PR DESCRIPTION
はじめまして。
私の環境で、VRChatActivityLogViewerのCopy*系のボタンをクリックした際にアプリケーションが予期せず終了してしまっていたため、それに対する対処を行ったものをPull Requestさせていただきます。

詳細:
各コピーボタンクリック時のイベント内の`Clipboard.SetText()`において
```System.Runtime.InteropServices.COMException: 'OpenClipboard に失敗しました (0x800401D0 (CLIPBRD_E_CANT_OPEN))'```
の例外が発生していました。

この例外について調べたところ、対処法として
* `Clipboard.SetDataObject()`を代わりに使用する
* `try/catch`で上記例外を握りつぶす

の2つが見つかり、そのいずれでも問題なくコピーが行われるようになりました。
しかし`try/catch`を行った場合、"Windowsのクリップボードの履歴"には表示されませんでした。
従って、当Pull Requestではすべての`Clipboard.SetText()`を`Clipboard.SetDataObject()`に置き換えて対処を行いました。

なお、この例外は他のアプリケーションがクリップボードを開いているタイミングで`Clipboard.SetText()`するなどで発生するようですが、残念ながら現在私の手元で具体的に原因となっているアプリケーションの特定には至っておりません。
また余談ですが`Clipboard.SetDataObject()`を使用した場合においても、第二引数に`true`を設定した場合、`Clipboard.SetText()`と同様の例外が発生しました。

以下は"Copy World ID"をクリックした際の例外の詳細です
```
System.Runtime.InteropServices.COMException
  HResult=0x800401D0
  Message=OpenClipboard に失敗しました (0x800401D0 (CLIPBRD_E_CANT_OPEN))
  Source=System.Private.CoreLib
  スタック トレース:
   at System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(Int32 errorCode, IntPtr errorInfo)
   at System.Windows.Clipboard.Flush()
   at System.Windows.Clipboard.CriticalSetDataObject(Object data, Boolean copy)
   at System.Windows.Clipboard.SetDataInternal(String format, Object data)
   at System.Windows.Clipboard.SetText(String text, TextDataFormat format)
   at System.Windows.Clipboard.SetText(String text)
   at VRChatActivityLogViewer.DetailWindow.CopyWorldIdButton_Click(Object sender, RoutedEventArgs e) in C:\Users\Shiokai\source\repos\VRChatActivityTools\VRChatActivityLogViewer\VRChatActivityLogViewer\DetailWindow.xaml.cs:line 273
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.Controls.Primitives.ButtonBase.OnClick()
   at System.Windows.Controls.Button.OnClick()
   at System.Windows.Controls.Primitives.ButtonBase.OnMouseLeftButtonUp(MouseButtonEventArgs e)
   at System.Windows.UIElement.OnMouseLeftButtonUpThunk(Object sender, MouseButtonEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.ReRaiseEventAs(DependencyObject sender, RoutedEventArgs args, RoutedEvent newEvent)
   at System.Windows.UIElement.OnMouseUpThunk(Object sender, MouseButtonEventArgs e)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Input.InputProviderSite.ReportInput(InputReport inputReport)
   at System.Windows.Interop.HwndMouseInputProvider.ReportInput(IntPtr hwnd, InputMode mode, Int32 timestamp, RawMouseActions actions, Int32 x, Int32 y, Int32 wheel)
   at System.Windows.Interop.HwndMouseInputProvider.FilterMessage(IntPtr hwnd, WindowMessage msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at System.Windows.Interop.HwndSource.InputFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)
   at MS.Win32.UnsafeNativeMethods.DispatchMessage(MSG& msg)
   at System.Windows.Threading.Dispatcher.PushFrameImpl(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at System.Windows.Threading.Dispatcher.Run()
   at System.Windows.Application.RunDispatcher(Object ignore)
   at System.Windows.Application.RunInternal(Window window)
   at System.Windows.Application.Run()
   at VRChatActivityLogViewer.App.Main()
```